### PR TITLE
Remove incorrect ',"err":null' output on examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -198,7 +198,7 @@ $ stringsvc1
 
 ```
 $ curl -XPOST -d'{"s":"hello, world"}' localhost:8080/uppercase
-{"v":"HELLO, WORLD","err":null}
+{"v":"HELLO, WORLD"}
 $ curl -XPOST -d'{"s":"hello, world"}' localhost:8080/count
 {"v":12}
 ```
@@ -436,7 +436,7 @@ msg=HTTP addr=:8080
 
 ```
 $ curl -XPOST -d'{"s":"hello, world"}' localhost:8080/uppercase
-{"v":"HELLO, WORLD","err":null}
+{"v":"HELLO, WORLD"}
 $ curl -XPOST -d'{"s":"hello, world"}' localhost:8080/count
 {"v":12}
 ```
@@ -609,9 +609,9 @@ listen=:8080 caller=main.go:72 msg=HTTP addr=:8080
 
 ```
 $ for s in foo bar baz ; do curl -d"{\"s\":\"$s\"}" localhost:8080/uppercase ; done
-{"v":"FOO","err":null}
-{"v":"BAR","err":null}
-{"v":"BAZ","err":null}
+{"v":"FOO"}
+{"v":"BAR"}
+{"v":"BAZ"}
 ```
 
 ```


### PR DESCRIPTION
Hi, 

I've updated the output on the example program's execution to remove the incorrect error message (the marshelling of empty errors is deliberately omitted in the code). This incorrect example output in the README might initially be confusing for anyone not familiar with the framework

Please feel free to ask any question :-)

Daniel
